### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,70 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
+
+      - name: Build WebAssembly package
+        run: wasm-pack build --target web --release
+        working-directory: GOL-core-rust
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: react-frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: react-frontend
+
+      - name: Build frontend
+        run: npm run build
+        working-directory: react-frontend
+
+      - name: Configure GitHub Pages
+        if: github.event_name != 'pull_request'
+        uses: actions/configure-pages@v5
+
+      - name: Upload GitHub Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: react-frontend/dist
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/react-frontend/package.json
+++ b/react-frontend/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "build-wasm": "cd ../GOL-core-rust && wasm-pack build --target web",
     "install-wasm": "npm install",
-    "update-wasm": "npm run wasm:build && npm run wasm:link",
+    "update-wasm": "npm run build-wasm && npm install",
     "start": "npm run build-wasm && npm run install-wasm && vite"
   },
   "dependencies": {

--- a/react-frontend/vite.config.ts
+++ b/react-frontend/vite.config.ts
@@ -6,6 +6,7 @@ import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/RustysGameofLife/',
   plugins: [react(), wasm()],
   server: {
     fs: {


### PR DESCRIPTION
## What changed

- configure Vite to build for the /RustysGameofLife/ project path
- add a GitHub Actions workflow that builds the Rust WebAssembly package and React frontend
- upload and deploy the production build through GitHub Pages
- run the complete build on pull requests without deploying
- repair the stale update-wasm npm script

## Why

The application currently runs locally through Vite and WebAssembly but has no reproducible GitHub Pages deployment. This adds that deployment path while preserving the existing browser-side architecture.

## Validation

- git diff --check
- workflow YAML parsed locally
- the pull request workflow performs the full Rust/WASM/TypeScript/Vite build in GitHub Actions because the local environment does not have Cargo or wasm-pack installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated deployment of the frontend to GitHub Pages.
  * Added support for manually triggering deployments and deploying updates from the main branch.

* **Bug Fixes**
  * Updated asset paths so the application loads correctly from its GitHub Pages subdirectory.
  * Improved the WebAssembly update process during frontend builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->