### PR TITLE
Fix GitHub Pages production build

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Rusty's Game of Life is Conway's Game of Life with the simulation core written in Rust and rendered through a React/WebAssembly frontend.
 
+**Live demo:** [Play Rusty's Game of Life](https://mattcattb.github.io/RustysGameofLife/)
+
 ## Screenshots
 
 ![Rusty's Game of Life simulation](docs/images/rustys-game-of-life.png)

--- a/react-frontend/src/App.tsx
+++ b/react-frontend/src/App.tsx
@@ -1,14 +1,9 @@
-import { useState } from 'react'
-
 import './styles/App.css'
 import GameOfLifeView from './views/GameOfLife';
 import { GameProvider } from './contexts/GameContext';
 import { Container } from '@mui/material';
 
 function App() {
-
-  const [page, setPage] = useState<string>("gol");
-
   return (
   <Container 
     maxWidth="xl"

--- a/react-frontend/src/components/Board/Cell.tsx
+++ b/react-frontend/src/components/Board/Cell.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 type Props = {
     color:string;
     onClick: () => void;

--- a/react-frontend/src/components/Palette/BlockPalette.tsx
+++ b/react-frontend/src/components/Palette/BlockPalette.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useGame } from '../../contexts/GameContext';
 
 import PaletteBlock  from './PaletteBlock';
@@ -15,7 +13,7 @@ export default function BlockPalette() {
   return (
     <div className='flex flex-row'>
       {GOLSettings.tileOptions.split('').map((c:string, id:number) => (
-        <PaletteBlock onClick={() => onPaletClick(id)} color={getCellColor(GOLSettings, c)} outline={tilePaletteSelected === c}/>
+        <PaletteBlock key={c} onClick={() => onPaletClick(id)} color={getCellColor(GOLSettings, c)} outline={tilePaletteSelected === c}/>
       ))}
     </div>
   )

--- a/react-frontend/src/components/Palette/PaletteBlock.tsx
+++ b/react-frontend/src/components/Palette/PaletteBlock.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Button from '../ui/Button'
 
 type Props = {
@@ -17,6 +16,6 @@ export default function PaletteBlock(props: Props) {
 
 
   return (
-    <Button onClick={props.onClick} style={buttonStyle}></Button>
+    <Button icon={null} label="" onClick={props.onClick} color="primary" style={buttonStyle} />
   )
 }

--- a/react-frontend/src/components/Settings/SettingsEditor.tsx
+++ b/react-frontend/src/components/Settings/SettingsEditor.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import { Dropdown } from '../ui/Dropdown';

--- a/react-frontend/src/views/Elements.tsx
+++ b/react-frontend/src/views/Elements.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 function ElementsView(){
   return (
     <div>Elements</div>

--- a/react-frontend/src/views/GameOfLife.tsx
+++ b/react-frontend/src/views/GameOfLife.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { 
   Box,
   Paper,
@@ -35,14 +35,18 @@ const PANELS = {
   }
 };
 
+type PanelKey = keyof typeof PANELS;
+
 function GameOfLifeView() {
   // Track which panel is currently open (if any)
-  const [activePanel, setActivePanel] = useState(null);
+  const [activePanel, setActivePanel] = useState<PanelKey | null>(null);
 
   // Toggle panel open/closed
-  const handlePanelClick = (panelKey) => {
+  const handlePanelClick = (panelKey: PanelKey) => {
     setActivePanel(activePanel === panelKey ? null : panelKey);
   };
+
+  const ActivePanel = activePanel ? PANELS[activePanel].component : null;
 
   return (
     <Box sx={{ 
@@ -61,7 +65,7 @@ function GameOfLifeView() {
         }}
       >
         <Stack spacing={1}>
-          {Object.entries(PANELS).map(([key, { icon, title }]) => (
+          {(Object.keys(PANELS) as PanelKey[]).map((key) => (
             <IconButton
               key={key}
               onClick={() => handlePanelClick(key)}
@@ -74,7 +78,7 @@ function GameOfLifeView() {
                 }
               }}
             >
-              {icon}
+              {PANELS[key].icon}
             </IconButton>
           ))}
         </Stack>
@@ -97,7 +101,7 @@ function GameOfLifeView() {
           }}
         >
           {/* Render the active panel's component */}
-          {activePanel && React.createElement(PANELS[activePanel].component)}
+          {ActivePanel && <ActivePanel />}
         </Paper>
       </Collapse>
 

--- a/react-frontend/vite.config.ts
+++ b/react-frontend/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import wasm from 'vite-plugin-wasm'
-import path from 'path';
 
 
 // https://vitejs.dev/config/
@@ -10,10 +9,7 @@ export default defineConfig({
   plugins: [react(), wasm()],
   server: {
     fs: {
-      allow:[
-        path.resolve('..', 'GOL-core-rust', 'pkg'),
-        './',
-      ]
+      allow: ['..']
     }
   }
 })


### PR DESCRIPTION
## What changed

- fix the strict TypeScript errors found by the first Pages workflow run
- retain Vite access to the generated sibling WASM package without Node path types
- add the live Pages URL to the README

## GitHub repository metadata

The repository Website field now points to https://mattcattb.github.io/RustysGameofLife/.

## Validation

- git diff --check
- the PR workflow builds Rust, WebAssembly, TypeScript, and the Vite production bundle